### PR TITLE
Support dynamic group creation through regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "ascii"
@@ -134,15 +134,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
 dependencies = [
  "shlex",
 ]
@@ -167,9 +167,9 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -263,12 +263,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -371,9 +371,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -382,16 +382,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -435,9 +429,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -630,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -652,16 +646,17 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -673,9 +668,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -685,9 +680,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -728,11 +723,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -817,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -865,7 +859,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.3",
+ "thiserror 2.0.6",
  "tokio",
  "tracing",
 ]
@@ -884,7 +878,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.3",
+ "thiserror 2.0.6",
  "tinyvec",
  "tracing",
  "web-time",
@@ -892,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
+checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1047,28 +1041,28 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "once_cell",
  "ring",
@@ -1121,18 +1115,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1199,9 +1193,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1233,9 +1227,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1244,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
 ]
@@ -1264,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
  "rustix",
  "windows-sys 0.59.0",
@@ -1283,11 +1277,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.6",
 ]
 
 [[package]]
@@ -1303,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1314,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -1335,9 +1329,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1383,9 +1377,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1398,12 +1392,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -1415,9 +1408,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -1425,9 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
@@ -1440,9 +1433,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1458,9 +1451,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1502,9 +1495,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1513,13 +1506,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1528,21 +1520,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1550,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1563,15 +1556,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1589,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.6"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1722,9 +1715,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -1734,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1767,18 +1760,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "env_logger",
  "log",
  "prometheus_exporter",
+ "regex",
  "reqwest",
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4.5.21", features = ["derive", "env", "wrap_help"] }
 env_logger = "0.11.5"
 log = "0.4.22"
 prometheus_exporter = { version = "0.8.5", features = ["logging"] }
+regex = "1.11.1"
 reqwest = { version = "0.12.9", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_yaml = "0.9.34"

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ This is a very simple Prometheus exporter, used for gathering metrics about grou
 
 The following statistics are gathered:
 
-| Metric                          | Description                                                  |
-|---------------------------------|--------------------------------------------------------------|
-| `esindex_grouped_indexes_total` | Number of indexes in group                                   |
-| `esindex_store_bytes`           | Total stored size of group in bytes                          |
-| `esindex_pri_store_bytes`       | Total primary stored size of group in bytes                  |
-| `esindex_sec_store_bytes`       | Total secondary (all replicas) stored size of group in bytes |
-| `esindex_docs_count_total`      | Total number of documents in group                           |
-| `esindex_docs_deleted_total`    | Total number of deleted documents in group                   |
+| Metric                            | Description                                                                               |
+|-----------------------------------|-------------------------------------------------------------------------------------------|
+| `esindex_grouped_indexes_total`   | Number of indexes in group                                                                |
+| `esindex_store_bytes`             | Total stored size of group in bytes                                                       |
+| `esindex_pri_store_bytes`         | Total primary stored size of group in bytes                                               |
+| `esindex_sec_store_bytes`         | Total secondary (all replicas) stored size of group in bytes                              |
+| `esindex_docs_count_total`        | Total number of documents in group                                                        |
+| `esindex_docs_deleted_total`      | Total number of deleted documents in group                                                |
+| `esindex_ungrouped_indexes_total` | Number of indexes that could not be made part of the group it was requested to be part of |
 
 Each metric is labeled with the group name, as the `group` label.
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -4,14 +4,13 @@ This page lists the licenses of the projects used in esindex_exporter.
 
 ## Overview of licenses
 
-- [Apache License 2.0](#Apache-2.0) (131)
+- [Apache License 2.0](#Apache-2.0) (130)
 - [MIT License](#MIT) (22)
-- [Unicode License v3](#Unicode-3.0) (19)
+- [Unicode License v3](#Unicode-3.0) (20)
 - [ISC License](#ISC) (4)
 - [BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License](#BSD-3-Clause) (1)
 - [Mozilla Public License 2.0](#MPL-2.0) (1)
 - [OpenSSL License](#OpenSSL) (1)
-- [Unicode License Agreement - Data Files and Software (2016)](#Unicode-DFS-2016) (1)
 
 ## All license text
 
@@ -656,8 +655,8 @@ This page lists the licenses of the projects used in esindex_exporter.
 
 #### Used by
 
-- [time-macros 0.2.18]( https://github.com/time-rs/time )
-- [time 0.3.36]( https://github.com/time-rs/time )
+- [time-macros 0.2.19]( https://github.com/time-rs/time )
+- [time 0.3.37]( https://github.com/time-rs/time )
 
 <pre>
 
@@ -1309,9 +1308,9 @@ This page lists the licenses of the projects used in esindex_exporter.
 
 #### Used by
 
-- [clap_builder 4.5.21]( https://github.com/clap-rs/clap )
+- [clap_builder 4.5.23]( https://github.com/clap-rs/clap )
 - [clap_derive 4.5.18]( https://github.com/clap-rs/clap )
-- [clap_lex 0.7.3]( https://github.com/clap-rs/clap )
+- [clap_lex 0.7.4]( https://github.com/clap-rs/clap )
 
 <pre>
                                  Apache License
@@ -2159,13 +2158,13 @@ This page lists the licenses of the projects used in esindex_exporter.
 - [anstyle-query 1.1.2]( https://github.com/rust-cli/anstyle.git )
 - [anstyle-wincon 3.0.6]( https://github.com/rust-cli/anstyle.git )
 - [anstyle 1.0.10]( https://github.com/rust-cli/anstyle.git )
-- [clap 4.5.21]( https://github.com/clap-rs/clap )
+- [clap 4.5.23]( https://github.com/clap-rs/clap )
 - [colorchoice 1.0.3]( https://github.com/rust-cli/anstyle.git )
 - [env_filter 0.1.2]( https://github.com/rust-cli/env_logger )
 - [env_logger 0.11.5]( https://github.com/rust-cli/env_logger )
 - [humantime 2.1.0]( https://github.com/tailhook/humantime )
 - [is_terminal_polyfill 1.70.1]( https://github.com/polyfill-rs/is_terminal_polyfill )
-- [terminal_size 0.4.0]( https://github.com/eminence/terminal-size )
+- [terminal_size 0.4.1]( https://github.com/eminence/terminal-size )
 
 <pre>
                                  Apache License
@@ -2805,7 +2804,7 @@ limitations under the License.
 
 #### Used by
 
-- [http 1.1.0]( https://github.com/hyperium/http )
+- [http 1.2.0]( https://github.com/hyperium/http )
 
 <pre>
                               Apache License
@@ -3016,7 +3015,7 @@ limitations under the License.
 
 #### Used by
 
-- [tokio-rustls 0.26.0]( https://github.com/rustls/tokio-rustls )
+- [tokio-rustls 0.26.1]( https://github.com/rustls/tokio-rustls )
 
 <pre>
                               Apache License
@@ -3655,24 +3654,23 @@ limitations under the License.
 - [base64 0.22.1]( https://github.com/marshallpierce/rust-base64 )
 - [bitflags 2.6.0]( https://github.com/bitflags/bitflags )
 - [bumpalo 3.16.0]( https://github.com/fitzgen/bumpalo )
-- [cc 1.2.1]( https://github.com/rust-lang/cc-rs )
+- [cc 1.2.3]( https://github.com/rust-lang/cc-rs )
 - [cfg-if 1.0.0]( https://github.com/alexcrichton/cfg-if )
 - [chunked_transfer 1.5.0]( https://github.com/frewsxcv/rust-chunked-transfer )
 - [displaydoc 0.2.5]( https://github.com/yaahc/displaydoc )
 - [equivalent 1.0.1]( https://github.com/cuviper/equivalent )
-- [errno 0.3.9]( https://github.com/lambda-fairy/rust-errno )
+- [errno 0.3.10]( https://github.com/lambda-fairy/rust-errno )
 - [fnv 1.0.7]( https://github.com/servo/rust-fnv )
 - [form_urlencoded 1.2.1]( https://github.com/servo/rust-url )
 - [gimli 0.31.1]( https://github.com/gimli-rs/gimli )
-- [hashbrown 0.15.1]( https://github.com/rust-lang/hashbrown )
+- [hashbrown 0.15.2]( https://github.com/rust-lang/hashbrown )
 - [heck 0.5.0]( https://github.com/withoutboats/heck )
-- [hermit-abi 0.3.9]( https://github.com/hermit-os/hermit-rs )
 - [httparse 1.9.5]( https://github.com/seanmonstar/httparse )
 - [hyper-rustls 0.27.3]( https://github.com/rustls/hyper-rustls )
 - [idna 1.0.3]( https://github.com/servo/rust-url/ )
 - [idna_adapter 1.2.0]( https://github.com/hsivonen/idna_adapter )
-- [indexmap 2.6.0]( https://github.com/indexmap-rs/indexmap )
-- [js-sys 0.3.72]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys )
+- [indexmap 2.7.0]( https://github.com/indexmap-rs/indexmap )
+- [js-sys 0.3.76]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys )
 - [lazy_static 1.5.0]( https://github.com/rust-lang-nursery/lazy-static.rs )
 - [linux-raw-sys 0.4.14]( https://github.com/sunfishcode/linux-raw-sys )
 - [lock_api 0.4.12]( https://github.com/Amanieu/parking_lot )
@@ -3687,23 +3685,23 @@ limitations under the License.
 - [regex-syntax 0.8.5]( https://github.com/rust-lang/regex/tree/master/regex-syntax )
 - [regex 1.11.1]( https://github.com/rust-lang/regex )
 - [rustc-demangle 0.1.24]( https://github.com/rust-lang/rustc-demangle )
-- [rustix 0.38.41]( https://github.com/bytecodealliance/rustix )
+- [rustix 0.38.42]( https://github.com/bytecodealliance/rustix )
 - [rustls-pemfile 2.2.0]( https://github.com/rustls/pemfile )
-- [rustls 0.23.17]( https://github.com/rustls/rustls )
+- [rustls 0.23.19]( https://github.com/rustls/rustls )
 - [scopeguard 1.2.0]( https://github.com/bluss/scopeguard )
 - [smallvec 1.13.2]( https://github.com/servo/rust-smallvec )
-- [socket2 0.5.7]( https://github.com/rust-lang/socket2 )
+- [socket2 0.5.8]( https://github.com/rust-lang/socket2 )
 - [stable_deref_trait 1.2.0]( https://github.com/storyyeller/stable_deref_trait )
 - [tiny_http 0.10.0]( https://github.com/tiny-http/tiny-http )
-- [url 2.5.3]( https://github.com/servo/rust-url )
+- [url 2.5.4]( https://github.com/servo/rust-url )
 - [wasi 0.11.0+wasi-snapshot-preview1]( https://github.com/bytecodealliance/wasi )
-- [wasm-bindgen-backend 0.2.95]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend )
-- [wasm-bindgen-futures 0.4.45]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures )
-- [wasm-bindgen-macro-support 0.2.95]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support )
-- [wasm-bindgen-macro 0.2.95]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro )
-- [wasm-bindgen-shared 0.2.95]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared )
-- [wasm-bindgen 0.2.95]( https://github.com/rustwasm/wasm-bindgen )
-- [web-sys 0.3.72]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys )
+- [wasm-bindgen-backend 0.2.99]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend )
+- [wasm-bindgen-futures 0.4.49]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures )
+- [wasm-bindgen-macro-support 0.2.99]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support )
+- [wasm-bindgen-macro 0.2.99]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro )
+- [wasm-bindgen-shared 0.2.99]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared )
+- [wasm-bindgen 0.2.99]( https://github.com/rustwasm/wasm-bindgen )
+- [web-sys 0.3.76]( https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys )
 
 <pre>
                               Apache License
@@ -4547,25 +4545,25 @@ limitations under the License.
 
 #### Used by
 
-- [anyhow 1.0.93]( https://github.com/dtolnay/anyhow )
-- [itoa 1.0.11]( https://github.com/dtolnay/itoa )
-- [libc 0.2.164]( https://github.com/rust-lang/libc )
+- [anyhow 1.0.94]( https://github.com/dtolnay/anyhow )
+- [itoa 1.0.14]( https://github.com/dtolnay/itoa )
+- [libc 0.2.168]( https://github.com/rust-lang/libc )
 - [miniz_oxide 0.8.0]( https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide )
 - [pin-project-lite 0.2.15]( https://github.com/taiki-e/pin-project-lite )
-- [proc-macro2 1.0.89]( https://github.com/dtolnay/proc-macro2 )
+- [proc-macro2 1.0.92]( https://github.com/dtolnay/proc-macro2 )
 - [quote 1.0.37]( https://github.com/dtolnay/quote )
 - [ryu 1.0.18]( https://github.com/dtolnay/ryu )
-- [serde 1.0.215]( https://github.com/serde-rs/serde )
-- [serde_derive 1.0.215]( https://github.com/serde-rs/serde )
+- [serde 1.0.216]( https://github.com/serde-rs/serde )
+- [serde_derive 1.0.216]( https://github.com/serde-rs/serde )
 - [serde_json 1.0.133]( https://github.com/serde-rs/json )
 - [serde_urlencoded 0.7.1]( https://github.com/nox/serde_urlencoded )
 - [serde_yaml 0.9.34+deprecated]( https://github.com/dtolnay/serde-yaml )
 - [shlex 1.3.0]( https://github.com/comex/rust-shlex )
-- [syn 2.0.87]( https://github.com/dtolnay/syn )
-- [sync_wrapper 1.0.1]( https://github.com/Actyx/sync_wrapper )
+- [syn 2.0.90]( https://github.com/dtolnay/syn )
+- [sync_wrapper 1.0.2]( https://github.com/Actyx/sync_wrapper )
 - [thiserror-impl 1.0.69]( https://github.com/dtolnay/thiserror )
 - [thiserror 1.0.69]( https://github.com/dtolnay/thiserror )
-- [unicode-ident 1.0.13]( https://github.com/dtolnay/unicode-ident )
+- [unicode-ident 1.0.14]( https://github.com/dtolnay/unicode-ident )
 - [utf8parse 0.2.2]( https://github.com/alacritty/vte )
 
 <pre>
@@ -4788,7 +4786,7 @@ pub(super) use verify::{check_name_constraints, GeneralName, NameIterator};
 
 #### Used by
 
-- [mio 1.0.2]( https://github.com/tokio-rs/mio )
+- [mio 1.0.3]( https://github.com/tokio-rs/mio )
 
 <pre>
 Copyright (c) 2014 Carl Lerche and other MIO contributors
@@ -4817,7 +4815,7 @@ THE SOFTWARE.
 
 #### Used by
 
-- [hyper 1.5.0]( https://github.com/hyperium/hyper )
+- [hyper 1.5.1]( https://github.com/hyperium/hyper )
 
 <pre>
 Copyright (c) 2014-2021 Sean McArthur
@@ -4908,7 +4906,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #### Used by
 
-- [bytes 1.8.0]( https://github.com/tokio-rs/bytes )
+- [bytes 1.9.0]( https://github.com/tokio-rs/bytes )
 
 <pre>
 Copyright (c) 2018 Carl Lerche
@@ -5074,8 +5072,8 @@ DEALINGS IN THE SOFTWARE.
 
 #### Used by
 
-- [tracing-core 0.1.32]( https://github.com/tokio-rs/tracing )
-- [tracing 0.1.40]( https://github.com/tokio-rs/tracing )
+- [tracing-core 0.1.33]( https://github.com/tokio-rs/tracing )
+- [tracing 0.1.41]( https://github.com/tokio-rs/tracing )
 
 <pre>
 Copyright (c) 2019 Tokio Contributors
@@ -5226,7 +5224,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 
 #### Used by
 
-- [tokio 1.41.1]( https://github.com/tokio-rs/tokio )
+- [tokio 1.42.0]( https://github.com/tokio-rs/tokio )
 
 <pre>
 MIT License
@@ -5416,7 +5414,7 @@ SOFTWARE.
 
 #### Used by
 
-- [webpki-roots 0.26.6]( https://github.com/rustls/webpki-roots )
+- [webpki-roots 0.26.7]( https://github.com/rustls/webpki-roots )
 
 <pre>
 Mozilla Public License Version 2.0
@@ -5861,6 +5859,55 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
 
 #### Used by
 
+- [unicode-ident 1.0.14]( https://github.com/dtolnay/unicode-ident )
+
+<pre>
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2023 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the &quot;Data Files&quot;) or
+software and any associated documentation (the &quot;Software&quot;) to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+
+</pre>
+
+### <a name="Unicode-3.0"></a>Unicode License v3
+
+#### Used by
+
 - [icu_collections 1.5.0]( https://github.com/unicode-org/icu4x )
 - [icu_locid 1.5.0]( https://github.com/unicode-org/icu4x )
 - [icu_locid_transform 1.5.0]( https://github.com/unicode-org/icu4x )
@@ -5871,13 +5918,13 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
 - [icu_properties_data 1.5.0]( https://github.com/unicode-org/icu4x )
 - [icu_provider 1.5.0]( https://github.com/unicode-org/icu4x )
 - [icu_provider_macros 1.5.0]( https://github.com/unicode-org/icu4x )
-- [litemap 0.7.3]( https://github.com/unicode-org/icu4x )
+- [litemap 0.7.4]( https://github.com/unicode-org/icu4x )
 - [tinystr 0.7.6]( https://github.com/unicode-org/icu4x )
 - [writeable 0.5.5]( https://github.com/unicode-org/icu4x )
-- [yoke-derive 0.7.4]( https://github.com/unicode-org/icu4x )
-- [yoke 0.7.4]( https://github.com/unicode-org/icu4x )
-- [zerofrom-derive 0.1.4]( https://github.com/unicode-org/icu4x )
-- [zerofrom 0.1.4]( https://github.com/unicode-org/icu4x )
+- [yoke-derive 0.7.5]( https://github.com/unicode-org/icu4x )
+- [yoke 0.7.5]( https://github.com/unicode-org/icu4x )
+- [zerofrom-derive 0.1.5]( https://github.com/unicode-org/icu4x )
+- [zerofrom 0.1.5]( https://github.com/unicode-org/icu4x )
 - [zerovec-derive 0.10.3]( https://github.com/unicode-org/icu4x )
 - [zerovec 0.10.4]( https://github.com/unicode-org/icu4x )
 
@@ -5928,38 +5975,6 @@ SPDX-License-Identifier: Unicode-3.0
 
 Portions of ICU4X may have been adapted from ICU4C and/or ICU4J.
 ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation and others.
-
-</pre>
-
-### <a name="Unicode-DFS-2016"></a>Unicode License Agreement - Data Files and Software (2016)
-
-#### Used by
-
-- [unicode-ident 1.0.13]( https://github.com/dtolnay/unicode-ident )
-
-<pre>
-UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
-
-Unicode Data Files include all data files under the directories http://www.unicode.org/Public/, http://www.unicode.org/reports/, http://www.unicode.org/cldr/data/, http://source.icu-project.org/repos/icu/, and http://www.unicode.org/utility/trac/browser/.
-
-Unicode Data Files do not include PDF online code charts under the directory http://www.unicode.org/Public/.
-
-Software includes any source code published in the Unicode Standard or under the directories http://www.unicode.org/Public/, http://www.unicode.org/reports/, http://www.unicode.org/cldr/data/, http://source.icu-project.org/repos/icu/, and http://www.unicode.org/utility/trac/browser/.
-
-NOTICE TO USER: Carefully read the following legal agreement. BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.&#x27;S DATA FILES (&quot;DATA FILES&quot;), AND/OR SOFTWARE (&quot;SOFTWARE&quot;), YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
-
-COPYRIGHT AND PERMISSION NOTICE
-
-Copyright © 1991-2016 Unicode, Inc. All rights reserved. Distributed under the Terms of Use in http://www.unicode.org/copyright.html.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of the Unicode data files and any associated documentation (the &quot;Data Files&quot;) or Unicode software and any associated documentation (the &quot;Software&quot;) to deal in the Data Files or Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, and/or sell copies of the Data Files or Software, and to permit persons to whom the Data Files or Software are furnished to do so, provided that either
-
-     (a) this copyright and permission notice appear with all copies of the Data Files or Software, or
-     (b) this copyright and permission notice appear in associated Documentation.
-
-THE DATA FILES AND SOFTWARE ARE PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA FILES OR SOFTWARE.
-
-Except as contained in this notice, the name of a copyright holder shall not be used in advertising or otherwise to promote the sale, use or other dealings in these Data Files or Software without prior written authorization of the copyright holder.
 
 </pre>
 

--- a/about.toml
+++ b/about.toml
@@ -11,6 +11,3 @@ no-clearly-defined = true
 
 [ring]
 accepted = ["OpenSSL"]
-
-[unicode-ident]
-accepted = ["Unicode-DFS-2016"]

--- a/deny.toml
+++ b/deny.toml
@@ -13,9 +13,6 @@ exceptions = [
     # ring uses code from multiple libraries but all with permissive licenses
     # https://tldrlegal.com/license/openssl-license-(openssl)
     { allow = ["ISC", "MIT", "OpenSSL"], name = "ring" },
-
-    # Unicode-DFS-2016 is a permissive license, if attribution in associated documentation is provided
-    { allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
 ]
 
 [[licenses.clarify]]

--- a/esindex_exporter.example.yaml
+++ b/esindex_exporter.example.yaml
@@ -4,12 +4,7 @@ groups:
 - name: "alb.access"
   index_patterns:
   - "alb.access-*"
-- name: "integration-alb.access"
+- name: "${environment}-alb.access"
   index_patterns:
-  - "integration-alb.access-*"
-- name: "preprod-alb.access"
-  index_patterns:
-  - "preprod-alb.access-*"
-- name: "production-alb.access"
-  index_patterns:
-  - "production-alb.access-*"
+  - "*-alb.access-*"
+  grouping_regex: '^(?<environment>[^-]+)-alb.access-.*$'

--- a/src/de.rs
+++ b/src/de.rs
@@ -26,3 +26,19 @@ where
     let s = String::deserialize(deserializer)?;
     T::from_str(&s).map_err(serde::de::Error::custom)
 }
+
+/// Deserialize an optional string as a regex.
+pub(crate) fn deserialize_optional_string_as_regex<'de, D>(
+    deserializer: D,
+) -> Result<Option<regex::Regex>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = Option::<String>::deserialize(deserializer)?;
+    match s {
+        Some(s) => regex::Regex::new(&s)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        None => Ok(None),
+    }
+}


### PR DESCRIPTION
There are various use-cases where one might want to use fairly generic index-patterns, but is still interested in scoping the results down further dynamically.

The example configuration demonstrates a use-case where access logs from AWS Application Load Balancers are collected by environment, but getting the data grouped by environment is still desired.

Before this change all environments had to be provided statically, now the index names can be grouped by applying a regex to them, and using capture-groups of this regex in the name of the group.

Closes https://github.com/takkt-ag/esindex_exporter/issues/3.